### PR TITLE
fix: combine cinemaFilm and cinemaScope aspect ratios into one 2:1 aspect ratio

### DIFF
--- a/src/aspect-ratios.ts
+++ b/src/aspect-ratios.ts
@@ -1,6 +1,5 @@
 type AspectRatio =
 	| 'cinemaFilm'
-	| 'cinemaScope'
 	| 'display'
 	| 'film'
 	| 'hdtv'
@@ -13,8 +12,7 @@ type AspectRatio =
 
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 const aspectRatioFractions: Record<AspectRatio, number> = {
-	cinemaFilm: 1.85 / 1,
-	cinemaScope: 2.35 / 1,
+	cinemaFilm: 2 / 1,
 	display: 5 / 4,
 	film: 3 / 2,
 	portrait: 3 / 4,
@@ -28,8 +26,7 @@ const aspectRatioFractions: Record<AspectRatio, number> = {
 /* eslint-enable @typescript-eslint/no-magic-numbers */
 
 const aspectRatioNotations: Record<AspectRatio, string> = {
-	cinemaFilm: '1.85:1',
-	cinemaScope: '2.35:1',
+	cinemaFilm: '2:1',
 	display: '5:4',
 	film: '3:2',
 	portrait: '3:4',


### PR DESCRIPTION
Hey @tristan-go thought I'd add a quick fix for the aspect ratio issue I keep coming across with the Dato Image component. If the aspect ratio has a decimal point (e.g. `cinemaFilm` is `1.85:1` and `cinemaScope` is `2.35:1`), the image is squashed instead of being resized correctly. See screenshot using our `cinemaFilm` ratio:

<img width="1307" alt="Screen Shot 2022-05-24 at 11 15 40 am" src="https://user-images.githubusercontent.com/63034375/169929226-fbdcf947-b834-4060-9020-93aa71466b71.png">

My suggested fix is to remove the decimal points from the ratios. Since the two are close in size to each other, I removed `cinemaScope` and changed `cinemaFilm` to `2:1`. Understand there may be some of our sites using `cinemaScope` already so we may have to update them.

If this goes through I've got an updated image for the documentation as well:

![aspect-ratios-updated](https://user-images.githubusercontent.com/63034375/169929864-94a0f7ad-d08c-4dbd-9410-c0b97e30b617.png)

